### PR TITLE
Use correct calculation for P-S

### DIFF
--- a/src/x25519_x64.c
+++ b/src/x25519_x64.c
@@ -209,11 +209,11 @@ static void x25519_keygen_precmp_x64(argKey session_key, argKey private_key) {
   Zr1[0] = 1;
   Zr2[0] = 1;
 
-  /* G-S */
-  Ur2[3] = 0x1eaecdeee27cab34;
-  Ur2[2] = 0xadc7a0b9235d48e2;
-  Ur2[1] = 0xbbf095ae14b2edf8;
-  Ur2[0] = 0x7e94e1fec82faabd;
+  /* P-S */
+  Ur2[3] = 0x215132111d8354cb;
+  Ur2[2] = 0x52385f46dca2b71d;
+  Ur2[1] = 0x440f6a51eb4d1207;
+  Ur2[0] = 0x816b1e0137d48290;
 
   /* main-loop */
   const int ite[4] = {64, 64, 64, 63};


### PR DESCRIPTION
The code used P+S instead of P-S. That's probably fine, having the same
order, but it doesn't match the description in the paper or proof
scripts. Another way of viewing the same thing would be to say that the
code used the negative Y coordinate instead of the positive one
mentioned in the paper.